### PR TITLE
refactor: improve MySQL module and add integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 .idea
 .pyc
 *.pyc
@@ -5,3 +6,4 @@
 MANIFEST
 __pycache__
 dist
+test/test_config.ini

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+pyanalysis is a Python utility library providing:
+- MySQL connection pooling (`pyanalysis.mysql`)
+- Logging handlers (`pyanalysis.logger`)
+- Email utilities (`pyanalysis.mail`)
+- Date/time utilities based on arrow (`pyanalysis.moment`)
+
+## Commands
+
+### Run tests
+```bash
+python3 -m unittest test/logger.py
+python3 -m unittest test/moment.py
+python3 -m unittest test/mysql.py
+python3 -m unittest test/mail.py
+```
+
+### Install dependencies
+```bash
+pip install -r requirements.txt
+```
+
+### Build and install locally
+```bash
+python3 setup.py sdist
+pip install dist/pyanalysis-2.0.2.tar.gz
+```
+
+Or use make:
+```bash
+make install
+```
+
+### Lint
+```bash
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+```
+
+## Architecture
+
+### MySQL Module (`pyanalysis/mysql.py`)
+- `Pool`: Connection pool with configurable size (3-100 connections), timeout, and retry logic
+- `Conn`: High-level database operations (`query`, `query_one`, `query_range`, `execute`, `insert`)
+- `Trans`: Transaction wrapper extending `Conn` with `commit`/`rollback` control
+- `_Connection`: Internal wrapper around `pymysql.Connection` with pool-aware lifecycle
+- SQL uses `?` placeholders (converted to `%s` internally)
+- Global pool registry via `add_pool()`/`get_pool()`
+
+### Logger Module (`pyanalysis/logger.py`)
+- `DebugHandler`: StreamHandler for development (DEBUG level)
+- `ReleaseRotatingFileHandler`: Size-based rotation (10MB, 10 backups, WARNING level)
+- `ReleaseTimedRotatingFileHandler`: Daily rotation (10 backups, WARNING level)
+- `AlarmSMTPHandler`: Email alerts for CRITICAL level
+
+### Mail Module (`pyanalysis/mail.py`)
+- `Mail`: SMTP client supporting SSL/TLS with attachments
+- `HtmlContent`, `ExcelAttach`, `ImageAttach`: Attachment helpers
+
+### Moment Module (`pyanalysis/moment.py`)
+- `Moment`: Extends `arrow.Arrow` with `second_timestamp`, `millisecond_timestamp`, `microsecond_timestamp` properties
+- `MomentFactory`: Handles 13-digit millisecond timestamps automatically
+- Use via `moment.now()`, `moment.get()`, etc.
+
+## Release Process
+
+Tag with `release-v*` pattern to trigger GitHub Actions build:
+```bash
+git tag -a release-v2.0.3 -m "v2.0.3"
+git push origin release-v2.0.3
+```

--- a/test/mysql.py
+++ b/test/mysql.py
@@ -1,3 +1,17 @@
+"""
+MySQL 模块单元测试
+
+本测试文件使用 Mock 技术对 pyanalysis.mysql 模块进行单元测试，
+无需连接真实数据库即可验证各组件的功能正确性。
+
+测试覆盖：
+- Pool: 连接池的创建、连接获取/归还、超时重试机制
+- Conn: 数据库连接的查询、执行、插入操作
+- Trans: 事务的开始、提交、回滚控制
+- 连接池注册表: add_pool/get_pool 全局函数
+- no_warning 装饰器
+"""
+
 import unittest
 from unittest.mock import Mock, patch, MagicMock
 import datetime
@@ -15,35 +29,51 @@ from pyanalysis.mysql import (
     get_pool,
 )
 
-# Access the internal __pool registry through the module
+# 通过模块访问内部的 __pool 注册表（用于测试清理）
 _pool_registry = mysql_module.__pool
 
 
 class TestPool(unittest.TestCase):
+    """
+    连接池 Pool 类的单元测试
+
+    测试连接池的核心功能：
+    - 连接池大小限制（最大100，最小3）
+    - 连接池名称生成规则
+    - 从池中获取连接（包括超时和重试机制）
+    - 将连接归还到池中
+    """
+
     def setUp(self):
+        """测试前准备：设置测试用的连接池名称"""
         self.pool_name = "test_pool"
 
     def tearDown(self):
+        """测试后清理：从全局注册表中移除测试连接池"""
         if self.pool_name in _pool_registry:
             del _pool_registry[self.pool_name]
 
     @patch("pyanalysis.mysql._Connection")
     def test_pool_size_limit_max(self, mock_conn_class):
+        """测试连接池大小上限：设置超过100时应被限制为100"""
         pool = Pool(size=150, name=self.pool_name, host="localhost")
         self.assertEqual(pool.size(), Pool._MAX_SIZE_LIMIT)
 
     @patch("pyanalysis.mysql._Connection")
     def test_pool_size_limit_min(self, mock_conn_class):
+        """测试连接池大小下限：设置小于3时应被限制为3"""
         pool = Pool(size=1, name=self.pool_name, host="localhost")
         self.assertEqual(pool.size(), Pool._MIN_SIZE_LIMIT)
 
     @patch("pyanalysis.mysql._Connection")
     def test_pool_normal_size(self, mock_conn_class):
+        """测试正常范围内的连接池大小：应保持设置值不变"""
         pool = Pool(size=5, name=self.pool_name, host="localhost")
         self.assertEqual(pool.size(), 5)
 
     @patch("pyanalysis.mysql._Connection")
     def test_pool_name_generation(self, mock_conn_class):
+        """测试连接池名称自动生成：未指定名称时应根据host-port-user-database生成"""
         pool = Pool(host="localhost", port=3306, user="test", database="testdb")
         self.assertIn("localhost", pool.name)
         self.assertIn("3306", pool.name)
@@ -52,6 +82,7 @@ class TestPool(unittest.TestCase):
 
     @patch("pyanalysis.mysql._Connection")
     def test_get_connection_success(self, mock_conn_class):
+        """测试成功获取连接：应返回连接对象并调用ping检查连接有效性"""
         mock_conn = MagicMock()
         mock_conn_class.return_value = mock_conn
 
@@ -63,15 +94,18 @@ class TestPool(unittest.TestCase):
 
     @patch("pyanalysis.mysql._Connection")
     def test_get_connection_timeout(self, mock_conn_class):
+        """测试获取连接超时：池中无可用连接且不重试时应抛出异常"""
         mock_conn = MagicMock()
         mock_conn_class.return_value = mock_conn
 
         pool = Pool(size=3, name=self.pool_name, host="localhost")
 
+        # 取走池中所有连接
         pool.get_connection(timeout=0)
         pool.get_connection(timeout=0)
         pool.get_connection(timeout=0)
 
+        # 再次获取应抛出异常
         with self.assertRaises(GetConnectionFromPoolError) as context:
             pool.get_connection(timeout=0, retry_num=0)
 
@@ -79,13 +113,16 @@ class TestPool(unittest.TestCase):
 
     @patch("pyanalysis.mysql._Connection")
     def test_get_connection_retry(self, mock_conn_class):
+        """测试获取连接重试机制：前两次失败后第三次成功应返回连接"""
         mock_conn = MagicMock()
         mock_conn_class.return_value = mock_conn
 
         pool = Pool(size=1, name=self.pool_name, host="localhost")
 
+        # 取走唯一的连接
         pool.get_connection(timeout=0)
 
+        # 模拟前两次获取失败，第三次成功
         original_get = pool._pool.get
         call_count = [0]
 
@@ -101,6 +138,7 @@ class TestPool(unittest.TestCase):
 
     @patch("pyanalysis.mysql._Connection")
     def test_put_connection(self, mock_conn_class):
+        """测试归还连接：取出后归还，池大小应恢复且连接的_pool属性应指向池"""
         mock_conn = MagicMock()
         mock_conn._pool = None
         mock_conn_class.return_value = mock_conn
@@ -108,36 +146,56 @@ class TestPool(unittest.TestCase):
         pool = Pool(size=3, name=self.pool_name, host="localhost")
         initial_size = pool.size()
 
+        # 取出一个连接，池大小减1
         conn = pool.get_connection(timeout=0)
         self.assertEqual(pool.size(), initial_size - 1)
 
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value = mock_cursor
 
+        # 归还连接，池大小恢复
         pool.put_connection(conn)
         self.assertEqual(pool.size(), initial_size)
         self.assertEqual(conn._pool, pool)
 
     @patch("pyanalysis.mysql._Connection")
     def test_put_connection_pool_accepts_extra(self, mock_conn_class):
+        """测试归还额外连接：池可以接受超过初始大小的连接（边界情况）"""
         mock_conn = MagicMock()
         mock_conn._pool = None
         mock_conn_class.return_value = mock_conn
 
         pool = Pool(size=3, name=self.pool_name, host="localhost")
 
+        # 创建一个不属于池的额外连接
         extra_conn = MagicMock()
         mock_cursor = MagicMock()
         extra_conn.cursor.return_value = mock_cursor
         extra_conn._pool = None
 
+        # 归还额外连接，池大小增加
         pool.put_connection(extra_conn)
         self.assertEqual(pool.size(), 4)
         self.assertEqual(extra_conn._pool, pool)
 
 
 class TestConn(unittest.TestCase):
+    """
+    数据库连接 Conn 类的单元测试
+
+    测试 Conn 类的核心功能：
+    - SQL 格式化（? 占位符转换为 %s）
+    - 输入数据编码（Decimal 转 float，datetime 转字符串）
+    - 单条查询 query_one
+    - 批量查询 query
+    - 分批查询 query_range（生成器方式）
+    - 执行语句 execute
+    - 插入语句 insert
+    - 获取原生连接和关闭连接
+    """
+
     def setUp(self):
+        """测试前准备：创建 mock 连接池并注册到全局注册表"""
         self.pool_name = "test_conn_db"
         self.mock_pool = MagicMock()
         self.mock_conn = MagicMock()
@@ -145,16 +203,19 @@ class TestConn(unittest.TestCase):
         _pool_registry[self.pool_name] = self.mock_pool
 
     def tearDown(self):
+        """测试后清理：从全局注册表中移除测试连接池"""
         if self.pool_name in _pool_registry:
             del _pool_registry[self.pool_name]
 
     def test_format_sql(self):
+        """测试 SQL 格式化：? 占位符应转换为 pymysql 使用的 %s"""
         conn = Conn(self.pool_name)
         sql = "SELECT * FROM users WHERE id = ? AND name = ?"
         formatted = conn._format_sql(sql)
         self.assertEqual(formatted, "SELECT * FROM users WHERE id = %s AND name = %s")
 
     def test_encode_input_decimal(self):
+        """测试输入编码 - Decimal 类型：应转换为 float"""
         conn = Conn(self.pool_name)
         row = {"price": decimal.Decimal("10.99"), "name": "test"}
         result = conn._encode_input(row)
@@ -162,6 +223,7 @@ class TestConn(unittest.TestCase):
         self.assertEqual(result["price"], 10.99)
 
     def test_encode_input_datetime(self):
+        """测试输入编码 - datetime 类型：应转换为格式化字符串"""
         conn = Conn(self.pool_name)
         dt = datetime.datetime(2023, 1, 1, 12, 30, 45)
         row = {"created_at": dt, "name": "test"}
@@ -169,6 +231,7 @@ class TestConn(unittest.TestCase):
         self.assertEqual(result["created_at"], "2023-01-01 12:30:45")
 
     def test_query_one_success(self):
+        """测试单条查询成功：应返回包含数据的字典"""
         mock_cursor = MagicMock()
         mock_cursor.fetchone.return_value = {"id": 1, "name": "test"}
         self.mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
@@ -182,6 +245,7 @@ class TestConn(unittest.TestCase):
         mock_cursor.execute.assert_called_once()
 
     def test_query_one_empty(self):
+        """测试单条查询无结果：应返回 None"""
         mock_cursor = MagicMock()
         mock_cursor.fetchone.return_value = None
         self.mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
@@ -192,6 +256,7 @@ class TestConn(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_query_success(self):
+        """测试批量查询成功：应返回包含多条记录的列表"""
         mock_cursor = MagicMock()
         mock_cursor.fetchall.return_value = [
             {"id": 1, "name": "test1"},
@@ -207,6 +272,7 @@ class TestConn(unittest.TestCase):
         self.assertEqual(result[1]["id"], 2)
 
     def test_query_empty(self):
+        """测试批量查询无结果：应返回空列表"""
         mock_cursor = MagicMock()
         mock_cursor.fetchall.return_value = []
         self.mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
@@ -217,7 +283,9 @@ class TestConn(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
     def test_query_range(self):
+        """测试分批查询：应通过生成器逐批返回所有结果"""
         mock_cursor = MagicMock()
+        # 模拟分三批返回数据：2条、2条、空（结束）
         mock_cursor.fetchmany.side_effect = [
             [{"id": 1}, {"id": 2}],
             [{"id": 3}, {"id": 4}],
@@ -232,6 +300,7 @@ class TestConn(unittest.TestCase):
         self.assertEqual([r["id"] for r in results], [1, 2, 3, 4])
 
     def test_query_range_custom_size(self):
+        """测试分批查询自定义批次大小：fetchmany 应使用指定的 size 参数"""
         mock_cursor = MagicMock()
         mock_cursor.fetchmany.side_effect = [[{"id": 1}], [{"id": 2}], []]
         self.mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
@@ -243,6 +312,7 @@ class TestConn(unittest.TestCase):
         mock_cursor.fetchmany.assert_called_with(size=1)
 
     def test_execute_success(self):
+        """测试执行语句成功：应返回受影响行数并自动提交事务"""
         mock_cursor = MagicMock()
         mock_cursor.execute.return_value = 5
         self.mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
@@ -254,6 +324,7 @@ class TestConn(unittest.TestCase):
         self.mock_conn.commit.assert_called_once()
 
     def test_insert_success(self):
+        """测试插入语句成功：应返回新插入行的 ID 并自动提交事务"""
         mock_cursor = MagicMock()
         mock_cursor.lastrowid = 100
         self.mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
@@ -265,18 +336,31 @@ class TestConn(unittest.TestCase):
         self.mock_conn.commit.assert_called_once()
 
     def test_get_native_conn(self):
+        """测试获取原生连接：应返回底层的 pymysql 连接对象"""
         conn = Conn(self.pool_name)
         native = conn.get_native_conn()
         self.assertEqual(native, self.mock_conn)
 
     def test_close(self):
+        """测试关闭连接：应调用底层连接的 close 方法"""
         conn = Conn(self.pool_name)
         conn.close()
         self.mock_conn.close.assert_called_once()
 
 
 class TestTrans(unittest.TestCase):
+    """
+    事务 Trans 类的单元测试
+
+    测试 Trans 类的核心功能：
+    - 创建事务时自动开启事务（调用 begin）
+    - execute/insert 不自动提交（与 Conn 不同）
+    - 手动提交 commit
+    - 手动回滚 rollback
+    """
+
     def setUp(self):
+        """测试前准备：创建 mock 连接池并注册到全局注册表"""
         self.pool_name = "test_trans_db"
         self.mock_pool = MagicMock()
         self.mock_conn = MagicMock()
@@ -284,15 +368,18 @@ class TestTrans(unittest.TestCase):
         _pool_registry[self.pool_name] = self.mock_pool
 
     def tearDown(self):
+        """测试后清理：从全局注册表中移除测试连接池"""
         if self.pool_name in _pool_registry:
             del _pool_registry[self.pool_name]
 
     def test_trans_begin_transaction(self):
+        """测试事务初始化：创建 Trans 对象时应自动调用 begin 开启事务"""
         trans = Trans(self.pool_name)
         self.assertIsNotNone(trans)
         self.mock_conn.begin.assert_called_once()
 
     def test_trans_execute_no_commit(self):
+        """测试事务中执行语句：应返回受影响行数但不自动提交"""
         mock_cursor = MagicMock()
         mock_cursor.execute.return_value = 3
         self.mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
@@ -301,9 +388,11 @@ class TestTrans(unittest.TestCase):
         result = trans.execute("UPDATE users SET name = ?", ("new_name",))
 
         self.assertEqual(result, 3)
+        # 关键断言：事务中不应自动提交
         self.mock_conn.commit.assert_not_called()
 
     def test_trans_insert_no_commit(self):
+        """测试事务中插入语句：应返回新行 ID 但不自动提交"""
         mock_cursor = MagicMock()
         mock_cursor.lastrowid = 200
         self.mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
@@ -312,29 +401,45 @@ class TestTrans(unittest.TestCase):
         result = trans.insert("INSERT INTO users (name) VALUES (?)", ("test",))
 
         self.assertEqual(result, 200)
+        # 关键断言：事务中不应自动提交
         self.mock_conn.commit.assert_not_called()
 
     def test_trans_commit(self):
+        """测试手动提交事务：调用 commit 应提交底层连接的事务"""
         trans = Trans(self.pool_name)
         trans.commit()
         self.mock_conn.commit.assert_called_once()
 
     def test_trans_rollback(self):
+        """测试手动回滚事务：调用 rollback 应回滚底层连接的事务"""
         trans = Trans(self.pool_name)
         trans.rollback()
         self.mock_conn.rollback.assert_called_once()
 
 
 class TestPoolRegistry(unittest.TestCase):
+    """
+    连接池全局注册表的单元测试
+
+    测试 add_pool 和 get_pool 全局函数：
+    - add_pool: 将连接池注册到全局注册表
+    - add_pool: 传入非 Pool 对象时应抛出异常
+    - get_pool: 根据名称获取已注册的连接池
+    - get_pool: 获取不存在的连接池时应抛出异常
+    """
+
     def setUp(self):
+        """测试前准备：设置测试用的连接池名称"""
         self.pool_name = "test_registry"
 
     def tearDown(self):
+        """测试后清理：从全局注册表中移除测试连接池"""
         if self.pool_name in _pool_registry:
             del _pool_registry[self.pool_name]
 
     @patch("pyanalysis.mysql._Connection")
     def test_add_pool(self, mock_conn_class):
+        """测试添加连接池：应成功注册到全局注册表"""
         mock_conn = MagicMock()
         mock_conn_class.return_value = mock_conn
 
@@ -345,6 +450,7 @@ class TestPoolRegistry(unittest.TestCase):
         self.assertEqual(_pool_registry[self.pool_name], pool)
 
     def test_add_pool_invalid_object(self):
+        """测试添加非法对象：传入非 Pool 对象应抛出 RuntimeError"""
         with self.assertRaises(RuntimeError) as context:
             add_pool("not a pool")
 
@@ -352,6 +458,7 @@ class TestPoolRegistry(unittest.TestCase):
 
     @patch("pyanalysis.mysql._Connection")
     def test_get_pool(self, mock_conn_class):
+        """测试获取连接池：应返回之前注册的连接池对象"""
         mock_conn = MagicMock()
         mock_conn_class.return_value = mock_conn
 
@@ -362,6 +469,7 @@ class TestPoolRegistry(unittest.TestCase):
         self.assertEqual(retrieved, pool)
 
     def test_get_pool_not_found(self):
+        """测试获取不存在的连接池：应抛出 RuntimeError"""
         with self.assertRaises(RuntimeError) as context:
             get_pool("nonexistent_pool")
 
@@ -369,8 +477,17 @@ class TestPoolRegistry(unittest.TestCase):
 
 
 class TestNoWarningDecorator(unittest.TestCase):
+    """
+    no_warning 装饰器的单元测试
+
+    测试装饰器功能：
+    - 被装饰的函数执行时应抑制警告信息
+    - 函数返回值应正常传递
+    """
+
     @patch("pyanalysis.mysql.warnings")
     def test_no_warning_decorator(self, mock_warnings):
+        """测试 no_warning 装饰器：应调用 catch_warnings 上下文管理器抑制警告"""
         @mysql_module.no_warning
         def function_with_warning():
             warnings.warn("test warning")

--- a/test/mysql_integration.py
+++ b/test/mysql_integration.py
@@ -1,0 +1,833 @@
+"""
+MySQL 模块集成测试
+
+本测试文件使用真实的 MySQL 服务器进行测试，验证各组件在实际环境中的功能正确性。
+
+配置方式（通过环境变量）：
+    MYSQL_HOST      - MySQL 服务器地址（默认：localhost）
+    MYSQL_PORT      - MySQL 服务器端口（默认：3306）
+    MYSQL_USER      - MySQL 用户名（默认：root）
+    MYSQL_PASSWORD  - MySQL 密码（默认：空）
+    MYSQL_DATABASE  - 测试数据库名称（默认：test_pyanalysis）
+
+运行方式：
+    # 设置环境变量后运行
+    export MYSQL_HOST=localhost
+    export MYSQL_USER=root
+    export MYSQL_PASSWORD=your_password
+    python3 -m unittest test/mysql_integration.py
+
+    # 或者一行命令
+    MYSQL_HOST=localhost MYSQL_USER=root MYSQL_PASSWORD=password python3 -m unittest test/mysql_integration.py
+
+测试覆盖：
+- Pool: 连接池的创建、连接获取/归还
+- Conn: 数据库连接的查询、执行、插入操作
+- Trans: 事务的提交、回滚控制
+"""
+
+import os
+import unittest
+import decimal
+import datetime
+
+import pymysql
+
+from pyanalysis.mysql import (
+    Pool,
+    Conn,
+    Trans,
+    add_pool,
+    get_pool,
+)
+import pyanalysis.mysql as mysql_module
+
+# 通过模块访问内部的 __pool 注册表（用于测试清理）
+_pool_registry = mysql_module.__pool
+
+
+def get_mysql_config():
+    """从环境变量获取 MySQL 配置"""
+    return {
+        "host": os.environ.get("MYSQL_HOST", "localhost"),
+        "port": int(os.environ.get("MYSQL_PORT", "3306")),
+        "user": os.environ.get("MYSQL_USER", "root"),
+        "password": os.environ.get("MYSQL_PASSWORD", ""),
+        "database": os.environ.get("MYSQL_DATABASE", "test_pyanalysis"),
+        "charset": "utf8mb4",
+    }
+
+
+def is_mysql_available():
+    """检查 MySQL 服务器是否可用"""
+    config = get_mysql_config()
+    try:
+        conn = pymysql.connect(
+            host=config["host"],
+            port=config["port"],
+            user=config["user"],
+            password=config["password"],
+            charset=config["charset"],
+        )
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+def setup_test_database():
+    """创建测试数据库（如果不存在）"""
+    config = get_mysql_config()
+    conn = pymysql.connect(
+        host=config["host"],
+        port=config["port"],
+        user=config["user"],
+        password=config["password"],
+        charset=config["charset"],
+    )
+    try:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                f"CREATE DATABASE IF NOT EXISTS `{config['database']}` "
+                "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# 如果 MySQL 不可用，跳过所有测试
+SKIP_TESTS = not is_mysql_available()
+SKIP_REASON = "MySQL server is not available. Set MYSQL_* environment variables."
+
+
+@unittest.skipIf(SKIP_TESTS, SKIP_REASON)
+class TestPoolIntegration(unittest.TestCase):
+    """
+    连接池 Pool 类的集成测试
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """测试类开始前：创建测试数据库"""
+        setup_test_database()
+        cls.config = get_mysql_config()
+        cls.pool_name = "test_pool_integration"
+
+    def tearDown(self):
+        """每个测试后清理：从全局注册表中移除测试连接池"""
+        if self.pool_name in _pool_registry:
+            del _pool_registry[self.pool_name]
+
+    def test_pool_creation(self):
+        """测试创建连接池：应成功创建指定大小的连接池"""
+        pool = Pool(
+            size=5,
+            name=self.pool_name,
+            host=self.config["host"],
+            port=self.config["port"],
+            user=self.config["user"],
+            password=self.config["password"],
+            database=self.config["database"],
+            charset=self.config["charset"],
+        )
+        self.assertEqual(pool.size(), 5)
+        self.assertEqual(pool.name, self.pool_name)
+
+    def test_get_and_put_connection(self):
+        """测试获取和归还连接：连接应能正常获取和归还"""
+        pool = Pool(
+            size=3,
+            name=self.pool_name,
+            host=self.config["host"],
+            port=self.config["port"],
+            user=self.config["user"],
+            password=self.config["password"],
+            database=self.config["database"],
+            charset=self.config["charset"],
+        )
+
+        # 获取连接
+        conn = pool.get_connection(timeout=5)
+        self.assertIsNotNone(conn)
+        self.assertEqual(pool.size(), 2)
+
+        # 归还连接
+        pool.put_connection(conn)
+        self.assertEqual(pool.size(), 3)
+
+    def test_connection_ping(self):
+        """测试连接活性检查：获取连接时应自动进行 ping 检查"""
+        pool = Pool(
+            size=3,
+            name=self.pool_name,
+            host=self.config["host"],
+            port=self.config["port"],
+            user=self.config["user"],
+            password=self.config["password"],
+            database=self.config["database"],
+            charset=self.config["charset"],
+        )
+
+        conn = pool.get_connection(timeout=5)
+        # 连接应该是有效的
+        conn.ping(reconnect=True)
+        pool.put_connection(conn)
+
+    def test_pool_registry(self):
+        """测试连接池注册表：add_pool 和 get_pool 应正常工作"""
+        pool = Pool(
+            size=3,
+            name=self.pool_name,
+            host=self.config["host"],
+            port=self.config["port"],
+            user=self.config["user"],
+            password=self.config["password"],
+            database=self.config["database"],
+            charset=self.config["charset"],
+        )
+
+        add_pool(pool)
+        retrieved = get_pool(self.pool_name)
+        self.assertEqual(retrieved, pool)
+
+
+@unittest.skipIf(SKIP_TESTS, SKIP_REASON)
+class TestConnIntegration(unittest.TestCase):
+    """
+    数据库连接 Conn 类的集成测试
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """测试类开始前：创建测试数据库和表"""
+        setup_test_database()
+        cls.config = get_mysql_config()
+        cls.pool_name = "test_conn_integration"
+
+        # 创建连接池
+        pool = Pool(
+            size=5,
+            name=cls.pool_name,
+            host=cls.config["host"],
+            port=cls.config["port"],
+            user=cls.config["user"],
+            password=cls.config["password"],
+            database=cls.config["database"],
+            charset=cls.config["charset"],
+        )
+        add_pool(pool)
+
+        # 创建测试表
+        cls._create_test_table()
+
+    @classmethod
+    def _create_test_table(cls):
+        """创建测试表"""
+        conn = Conn(cls.pool_name)
+        try:
+            conn.execute("DROP TABLE IF EXISTS test_users")
+            conn.execute("""
+                CREATE TABLE test_users (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    name VARCHAR(100) NOT NULL,
+                    email VARCHAR(100),
+                    balance DECIMAL(10, 2) DEFAULT 0.00,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+            """)
+        finally:
+            conn.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        """测试类结束后：清理测试表和连接池"""
+        # 先取出并关闭池中所有连接
+        if cls.pool_name in _pool_registry:
+            pool = _pool_registry[cls.pool_name]
+            while pool.size() > 0:
+                try:
+                    conn = pool._pool.get_nowait()
+                    conn._pool = None
+                    pymysql.connections.Connection.close(conn)
+                except Exception:
+                    break
+            del _pool_registry[cls.pool_name]
+
+        # 使用直接连接删除表
+        try:
+            direct_conn = pymysql.connect(
+                host=cls.config["host"],
+                port=cls.config["port"],
+                user=cls.config["user"],
+                password=cls.config["password"],
+                database=cls.config["database"],
+                charset=cls.config["charset"],
+            )
+            try:
+                with direct_conn.cursor() as cursor:
+                    cursor.execute("DROP TABLE IF EXISTS test_users")
+                direct_conn.commit()
+            finally:
+                direct_conn.close()
+        except Exception:
+            pass
+
+    def setUp(self):
+        """每个测试前：清空测试表数据"""
+        # 使用直接连接避免连接池中的连接状态问题
+        direct_conn = pymysql.connect(
+            host=self.config["host"],
+            port=self.config["port"],
+            user=self.config["user"],
+            password=self.config["password"],
+            database=self.config["database"],
+            charset=self.config["charset"],
+        )
+        try:
+            with direct_conn.cursor() as cursor:
+                cursor.execute("TRUNCATE TABLE test_users")
+            direct_conn.commit()
+        finally:
+            direct_conn.close()
+
+    def test_insert_and_query_one(self):
+        """测试插入和单条查询：插入后应能查询到数据"""
+        conn = Conn(self.pool_name)
+        try:
+            # 插入数据
+            user_id = conn.insert(
+                "INSERT INTO test_users (name, email) VALUES (?, ?)",
+                ("张三", "zhangsan@example.com"),
+            )
+            self.assertIsNotNone(user_id)
+            self.assertGreater(user_id, 0)
+
+            # 查询数据
+            result = conn.query_one(
+                "SELECT * FROM test_users WHERE id = ?", (user_id,)
+            )
+            self.assertIsNotNone(result)
+            self.assertEqual(result["name"], "张三")
+            self.assertEqual(result["email"], "zhangsan@example.com")
+        finally:
+            conn.close()
+
+    def test_query_multiple(self):
+        """测试批量查询：应返回所有匹配的记录"""
+        conn = Conn(self.pool_name)
+        try:
+            # 插入多条数据
+            conn.insert(
+                "INSERT INTO test_users (name, email) VALUES (?, ?)",
+                ("用户1", "user1@example.com"),
+            )
+            conn.insert(
+                "INSERT INTO test_users (name, email) VALUES (?, ?)",
+                ("用户2", "user2@example.com"),
+            )
+            conn.insert(
+                "INSERT INTO test_users (name, email) VALUES (?, ?)",
+                ("用户3", "user3@example.com"),
+            )
+
+            # 查询所有数据
+            results = conn.query("SELECT * FROM test_users ORDER BY id")
+            self.assertEqual(len(results), 3)
+            self.assertEqual(results[0]["name"], "用户1")
+            self.assertEqual(results[1]["name"], "用户2")
+            self.assertEqual(results[2]["name"], "用户3")
+        finally:
+            conn.close()
+
+    def test_query_empty(self):
+        """测试空查询结果：无匹配数据时应返回空列表"""
+        conn = Conn(self.pool_name)
+        try:
+            results = conn.query("SELECT * FROM test_users WHERE id = 99999")
+            self.assertEqual(len(results), 0)
+        finally:
+            conn.close()
+
+    def test_query_one_empty(self):
+        """测试单条空查询结果：无匹配数据时应返回 None"""
+        conn = Conn(self.pool_name)
+        try:
+            result = conn.query_one("SELECT * FROM test_users WHERE id = 99999")
+            self.assertIsNone(result)
+        finally:
+            conn.close()
+
+    def test_execute_update(self):
+        """测试执行更新语句：应返回受影响行数"""
+        conn = Conn(self.pool_name)
+        try:
+            # 插入数据
+            conn.insert(
+                "INSERT INTO test_users (name, email) VALUES (?, ?)",
+                ("测试用户", "test@example.com"),
+            )
+
+            # 更新数据
+            affected = conn.execute(
+                "UPDATE test_users SET name = ? WHERE email = ?",
+                ("更新后的用户", "test@example.com"),
+            )
+            self.assertEqual(affected, 1)
+
+            # 验证更新
+            result = conn.query_one(
+                "SELECT * FROM test_users WHERE email = ?", ("test@example.com",)
+            )
+            self.assertEqual(result["name"], "更新后的用户")
+        finally:
+            conn.close()
+
+    def test_execute_delete(self):
+        """测试执行删除语句：应返回受影响行数"""
+        conn = Conn(self.pool_name)
+        try:
+            # 插入数据
+            conn.insert(
+                "INSERT INTO test_users (name, email) VALUES (?, ?)",
+                ("待删除用户", "delete@example.com"),
+            )
+
+            # 删除数据
+            affected = conn.execute(
+                "DELETE FROM test_users WHERE email = ?", ("delete@example.com",)
+            )
+            self.assertEqual(affected, 1)
+
+            # 验证删除
+            result = conn.query_one(
+                "SELECT * FROM test_users WHERE email = ?", ("delete@example.com",)
+            )
+            self.assertIsNone(result)
+        finally:
+            conn.close()
+
+    def test_query_range(self):
+        """测试分批查询：应通过生成器逐批返回所有结果"""
+        conn = Conn(self.pool_name)
+        try:
+            # 插入多条数据
+            for i in range(10):
+                conn.insert(
+                    "INSERT INTO test_users (name, email) VALUES (?, ?)",
+                    (f"用户{i}", f"user{i}@example.com"),
+                )
+
+            # 分批查询（每批 3 条）
+            results = list(
+                conn.query_range("SELECT * FROM test_users ORDER BY id", size=3)
+            )
+            self.assertEqual(len(results), 10)
+
+            # 验证顺序
+            for i, result in enumerate(results):
+                self.assertEqual(result["name"], f"用户{i}")
+        finally:
+            conn.close()
+
+    def test_decimal_encoding(self):
+        """测试 Decimal 类型编码：Decimal 应正确转换为 float"""
+        conn = Conn(self.pool_name)
+        try:
+            # 插入带 Decimal 的数据
+            conn.insert(
+                "INSERT INTO test_users (name, balance) VALUES (?, ?)",
+                ("余额测试", decimal.Decimal("123.45")),
+            )
+
+            # 查询并验证类型转换
+            result = conn.query_one(
+                "SELECT * FROM test_users WHERE name = ?", ("余额测试",)
+            )
+            self.assertIsNotNone(result)
+            self.assertIsInstance(result["balance"], float)
+            self.assertAlmostEqual(result["balance"], 123.45, places=2)
+        finally:
+            conn.close()
+
+    def test_datetime_encoding(self):
+        """测试 datetime 类型编码：datetime 应正确转换为字符串"""
+        conn = Conn(self.pool_name)
+        try:
+            # 插入数据
+            user_id = conn.insert(
+                "INSERT INTO test_users (name, email) VALUES (?, ?)",
+                ("时间测试", "time@example.com"),
+            )
+
+            # 查询并验证 datetime 转换
+            result = conn.query_one(
+                "SELECT * FROM test_users WHERE id = ?", (user_id,)
+            )
+            self.assertIsNotNone(result)
+            # created_at 应被转换为字符串格式
+            self.assertIsInstance(result["created_at"], str)
+        finally:
+            conn.close()
+
+
+@unittest.skipIf(SKIP_TESTS, SKIP_REASON)
+class TestTransIntegration(unittest.TestCase):
+    """
+    事务 Trans 类的集成测试
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """测试类开始前：创建测试数据库和表"""
+        setup_test_database()
+        cls.config = get_mysql_config()
+        cls.pool_name = "test_trans_integration"
+
+        # 创建连接池
+        pool = Pool(
+            size=5,
+            name=cls.pool_name,
+            host=cls.config["host"],
+            port=cls.config["port"],
+            user=cls.config["user"],
+            password=cls.config["password"],
+            database=cls.config["database"],
+            charset=cls.config["charset"],
+        )
+        add_pool(pool)
+
+        # 创建测试表
+        cls._create_test_table()
+
+    @classmethod
+    def _create_test_table(cls):
+        """创建测试表"""
+        conn = Conn(cls.pool_name)
+        try:
+            conn.execute("DROP TABLE IF EXISTS test_accounts")
+            conn.execute("""
+                CREATE TABLE test_accounts (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    name VARCHAR(100) NOT NULL,
+                    balance DECIMAL(10, 2) DEFAULT 0.00
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+            """)
+        finally:
+            conn.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        """测试类结束后：清理测试表和连接池"""
+        # 先取出并关闭池中所有连接
+        if cls.pool_name in _pool_registry:
+            pool = _pool_registry[cls.pool_name]
+            while pool.size() > 0:
+                try:
+                    conn = pool._pool.get_nowait()
+                    conn._pool = None
+                    pymysql.connections.Connection.close(conn)
+                except Exception:
+                    break
+            del _pool_registry[cls.pool_name]
+
+        # 使用直接连接删除表
+        try:
+            direct_conn = pymysql.connect(
+                host=cls.config["host"],
+                port=cls.config["port"],
+                user=cls.config["user"],
+                password=cls.config["password"],
+                database=cls.config["database"],
+                charset=cls.config["charset"],
+            )
+            try:
+                with direct_conn.cursor() as cursor:
+                    cursor.execute("DROP TABLE IF EXISTS test_accounts")
+                direct_conn.commit()
+            finally:
+                direct_conn.close()
+        except Exception:
+            pass
+
+    def setUp(self):
+        """每个测试前：清空测试表并插入初始数据"""
+        # 使用直接连接避免连接池中的连接状态问题
+        direct_conn = pymysql.connect(
+            host=self.config["host"],
+            port=self.config["port"],
+            user=self.config["user"],
+            password=self.config["password"],
+            database=self.config["database"],
+            charset=self.config["charset"],
+        )
+        try:
+            with direct_conn.cursor() as cursor:
+                cursor.execute("TRUNCATE TABLE test_accounts")
+                cursor.execute(
+                    "INSERT INTO test_accounts (name, balance) VALUES (%s, %s)",
+                    ("账户A", 1000.00),
+                )
+                cursor.execute(
+                    "INSERT INTO test_accounts (name, balance) VALUES (%s, %s)",
+                    ("账户B", 500.00),
+                )
+            direct_conn.commit()
+        finally:
+            direct_conn.close()
+
+    def test_transaction_commit(self):
+        """测试事务提交：提交后数据应持久化"""
+        trans = Trans(self.pool_name)
+        try:
+            # 模拟转账：A -> B 转 100
+            trans.execute(
+                "UPDATE test_accounts SET balance = balance - ? WHERE name = ?",
+                (100, "账户A"),
+            )
+            trans.execute(
+                "UPDATE test_accounts SET balance = balance + ? WHERE name = ?",
+                (100, "账户B"),
+            )
+            trans.commit()
+        finally:
+            trans.close()
+
+        # 验证数据已持久化
+        conn = Conn(self.pool_name)
+        try:
+            account_a = conn.query_one(
+                "SELECT * FROM test_accounts WHERE name = ?", ("账户A",)
+            )
+            account_b = conn.query_one(
+                "SELECT * FROM test_accounts WHERE name = ?", ("账户B",)
+            )
+
+            self.assertAlmostEqual(account_a["balance"], 900.00, places=2)
+            self.assertAlmostEqual(account_b["balance"], 600.00, places=2)
+        finally:
+            conn.close()
+
+    def test_transaction_rollback(self):
+        """测试事务回滚：回滚后数据应恢复原状"""
+        trans = Trans(self.pool_name)
+        try:
+            # 模拟转账：A -> B 转 100
+            trans.execute(
+                "UPDATE test_accounts SET balance = balance - ? WHERE name = ?",
+                (100, "账户A"),
+            )
+            trans.execute(
+                "UPDATE test_accounts SET balance = balance + ? WHERE name = ?",
+                (100, "账户B"),
+            )
+            # 回滚事务
+            trans.rollback()
+        finally:
+            trans.close()
+
+        # 验证数据未改变
+        conn = Conn(self.pool_name)
+        try:
+            account_a = conn.query_one(
+                "SELECT * FROM test_accounts WHERE name = ?", ("账户A",)
+            )
+            account_b = conn.query_one(
+                "SELECT * FROM test_accounts WHERE name = ?", ("账户B",)
+            )
+
+            self.assertAlmostEqual(account_a["balance"], 1000.00, places=2)
+            self.assertAlmostEqual(account_b["balance"], 500.00, places=2)
+        finally:
+            conn.close()
+
+    def test_transaction_insert(self):
+        """测试事务中插入：提交后应能查询到新数据"""
+        trans = Trans(self.pool_name)
+        try:
+            new_id = trans.insert(
+                "INSERT INTO test_accounts (name, balance) VALUES (?, ?)",
+                ("账户C", decimal.Decimal("200.00")),
+            )
+            self.assertIsNotNone(new_id)
+            self.assertGreater(new_id, 0)
+            trans.commit()
+        finally:
+            trans.close()
+
+        # 验证数据已插入
+        conn = Conn(self.pool_name)
+        try:
+            account_c = conn.query_one(
+                "SELECT * FROM test_accounts WHERE name = ?", ("账户C",)
+            )
+            self.assertIsNotNone(account_c)
+            self.assertAlmostEqual(account_c["balance"], 200.00, places=2)
+        finally:
+            conn.close()
+
+    def test_transaction_insert_rollback(self):
+        """测试事务中插入后回滚：回滚后新数据应不存在"""
+        trans = Trans(self.pool_name)
+        try:
+            trans.insert(
+                "INSERT INTO test_accounts (name, balance) VALUES (?, ?)",
+                ("账户D", decimal.Decimal("300.00")),
+            )
+            trans.rollback()
+        finally:
+            trans.close()
+
+        # 验证数据未插入
+        conn = Conn(self.pool_name)
+        try:
+            account_d = conn.query_one(
+                "SELECT * FROM test_accounts WHERE name = ?", ("账户D",)
+            )
+            self.assertIsNone(account_d)
+        finally:
+            conn.close()
+
+
+@unittest.skipIf(SKIP_TESTS, SKIP_REASON)
+class TestConcurrentAccess(unittest.TestCase):
+    """
+    并发访问测试
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """测试类开始前：创建测试数据库和表"""
+        setup_test_database()
+        cls.config = get_mysql_config()
+        cls.pool_name = "test_concurrent_integration"
+
+        # 创建连接池
+        pool = Pool(
+            size=10,
+            name=cls.pool_name,
+            host=cls.config["host"],
+            port=cls.config["port"],
+            user=cls.config["user"],
+            password=cls.config["password"],
+            database=cls.config["database"],
+            charset=cls.config["charset"],
+        )
+        add_pool(pool)
+
+        # 创建测试表
+        cls._create_test_table()
+
+    @classmethod
+    def _create_test_table(cls):
+        """创建测试表"""
+        conn = Conn(cls.pool_name)
+        try:
+            conn.execute("DROP TABLE IF EXISTS test_counter")
+            conn.execute("""
+                CREATE TABLE test_counter (
+                    id INT PRIMARY KEY,
+                    count INT DEFAULT 0
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+            """)
+            conn.insert("INSERT INTO test_counter (id, count) VALUES (?, ?)", (1, 0))
+        finally:
+            conn.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        """测试类结束后：清理测试表和连接池"""
+        # 先取出并关闭池中所有连接
+        if cls.pool_name in _pool_registry:
+            pool = _pool_registry[cls.pool_name]
+            while pool.size() > 0:
+                try:
+                    conn = pool._pool.get_nowait()
+                    conn._pool = None  # 防止 close 时放回池中
+                    pymysql.connections.Connection.close(conn)
+                except Exception:
+                    break
+            del _pool_registry[cls.pool_name]
+
+        # 使用直接连接删除表
+        try:
+            direct_conn = pymysql.connect(
+                host=cls.config["host"],
+                port=cls.config["port"],
+                user=cls.config["user"],
+                password=cls.config["password"],
+                database=cls.config["database"],
+                charset=cls.config["charset"],
+            )
+            try:
+                with direct_conn.cursor() as cursor:
+                    cursor.execute("DROP TABLE IF EXISTS test_counter")
+                direct_conn.commit()
+            finally:
+                direct_conn.close()
+        except Exception:
+            pass
+
+    def test_multiple_connections(self):
+        """测试多个连接同时操作：应能正确处理并发访问"""
+        import threading
+
+        errors = []
+        results = []
+
+        def increment_counter():
+            try:
+                conn = Conn(self.pool_name)
+                try:
+                    conn.execute(
+                        "UPDATE test_counter SET count = count + 1 WHERE id = ?", (1,)
+                    )
+                    result = conn.query_one(
+                        "SELECT count FROM test_counter WHERE id = ?", (1,)
+                    )
+                    results.append(result["count"])
+                finally:
+                    conn.close()
+            except Exception as e:
+                errors.append(str(e))
+
+        # 创建多个线程同时操作
+        threads = []
+        for _ in range(5):
+            t = threading.Thread(target=increment_counter)
+            threads.append(t)
+
+        for t in threads:
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        # 验证无错误发生
+        self.assertEqual(len(errors), 0, f"Errors occurred: {errors}")
+
+        # 验证最终计数
+        conn = Conn(self.pool_name)
+        try:
+            result = conn.query_one(
+                "SELECT count FROM test_counter WHERE id = ?", (1,)
+            )
+            self.assertEqual(result["count"], 5)
+        finally:
+            conn.close()
+
+
+if __name__ == "__main__":
+    if SKIP_TESTS:
+        print("=" * 60)
+        print("WARNING: MySQL server is not available!")
+        print("Please set the following environment variables:")
+        print("  MYSQL_HOST     - MySQL server host (default: localhost)")
+        print("  MYSQL_PORT     - MySQL server port (default: 3306)")
+        print("  MYSQL_USER     - MySQL username (default: root)")
+        print("  MYSQL_PASSWORD - MySQL password (default: empty)")
+        print("  MYSQL_DATABASE - Test database name (default: test_pyanalysis)")
+        print("=" * 60)
+        print()
+
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix connection cleanup in `put_connection`: use `rollback()` instead of closing cursor to properly clean up connection state
- Fix `query_one`: use `DictCursor` instead of `SSDictCursor` to avoid unbuffered cursor connection issues
- Fix `Trans.execute/insert`: use `cursor.mogrify` instead of `conn.mogrify`
- Add comprehensive Chinese docstrings to unit tests
- Add integration tests for real MySQL (5.7 and 8.4)
- Add CLAUDE.md project instructions
- Update .gitignore

## Test plan
- [ ] Run unit tests: `python3 -m unittest test/mysql.py`
- [ ] Run integration tests with MySQL 8.4
- [ ] Run integration tests with MySQL 5.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)