### PR TITLE
ci: add MySQL integration tests with multi-version matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,46 @@ jobs:
         python -m unittest test/logger.py
         python -m unittest test/mysql.py
 
+  integration-test:
+    name: MySQL Integration Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mysql-version: ['5.7', '8.0', '8.4']
+
+    services:
+      mysql:
+        image: mysql:${{ matrix.mysql-version }}
+        env:
+          MYSQL_ROOT_PASSWORD: testpassword
+          MYSQL_DATABASE: test_pyanalysis
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run MySQL integration tests
+      env:
+        MYSQL_HOST: 127.0.0.1
+        MYSQL_PORT: 3306
+        MYSQL_USER: root
+        MYSQL_PASSWORD: testpassword
+        MYSQL_DATABASE: test_pyanalysis
+      run: |
+        python -m unittest test/mysql_integration.py
+
 


### PR DESCRIPTION
## Summary

Add MySQL integration tests to the CI workflow, testing against multiple MySQL versions.

## Changes

- Add `integration-test` job to `build.yml`
- Test against MySQL 5.7, 8.0, 8.4 using GitHub Actions service containers
- Run `test/mysql_integration.py` with proper environment variables

## Workflow Structure

| Job | Description |
|-----|-------------|
| `build` | Unit tests (Python 3.8, 3.9, 3.12) |
| `integration-test` | MySQL integration tests (MySQL 5.7, 8.0, 8.4) |

## Test plan

- [ ] Verify MySQL 5.7 integration tests pass
- [ ] Verify MySQL 8.0 integration tests pass
- [ ] Verify MySQL 8.4 integration tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)