### PR TITLE
ci: add release workflow for GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install build tools
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build package
+      run: python -m build
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true
+        files: |
+          dist/*.tar.gz
+          dist/*.whl


### PR DESCRIPTION
## Summary

Add automated release workflow that triggers when version tags are pushed.

## Features

- Triggers on `v*` tags (e.g., `v2.0.3`)
- Builds both sdist (`.tar.gz`) and wheel (`.whl`) packages
- Creates GitHub Release page with auto-generated release notes
- Uploads build artifacts as downloadable assets

## Usage

```bash
git tag -a v2.0.3 -m "v2.0.3"
git push origin v2.0.3
```

## Release Assets

Users can install directly from release assets:
```bash
pip install https://github.com/strengthening/pyanalysis/releases/download/v2.0.3/pyanalysis-2.0.3-py3-none-any.whl
```

🤖 Generated with [Claude Code](https://claude.ai/code)