### PR TITLE
ci: run build workflow before release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,13 @@ on:
       - 'v*'
 
 jobs:
+  build:
+    name: Run Build Workflow
+    uses: ./.github/workflows/build.yml
+
   release:
     name: Build and Release
+    needs: build
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- Add `workflow_call` trigger to build.yml to enable reuse by other workflows
- Modify release.yml to call build workflow first with `needs` dependency
- Release job will only execute if build passes (lint, unit tests, integration tests)

## Test plan
- [ ] Push a `v*` tag to verify build runs before release
- [ ] Verify release is blocked if build fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)