### PR TITLE
ci: auto sync version from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Update version from tag
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/v}
+        echo "Version: $VERSION"
+        sed -i "s/__version__ = \".*\"/__version__ = \"$VERSION\"/" pyanalysis/__init__.py
+        cat pyanalysis/__init__.py
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
## Summary
- Extract version from git tag (e.g., `v1.0.0` → `1.0.0`)
- Update `pyanalysis/__init__.py` before building package
- Ensures package version always matches the release tag

## Test plan
- [ ] Merge this PR
- [ ] Push a tag like `v1.0.0`
- [ ] Verify release artifacts are named `pyanalysis-1.0.0-*.whl` and `pyanalysis-1.0.0.tar.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)