### PR TITLE
feat: add Jinja2-based email template system

### DIFF
--- a/pyanalysis/templates/__init__.py
+++ b/pyanalysis/templates/__init__.py
@@ -1,0 +1,41 @@
+"""Email template system for pyanalysis.mail.
+
+This module provides Jinja2-based HTML email templates that are
+compatible with all major email clients including Outlook.
+
+Available Templates:
+    - NotificationTemplate: System notifications, reminders, password resets
+    - TableTemplate: Data reports, list displays, daily reports
+    - AlertTemplate: Exception alerts, monitoring notifications
+    - StatusTemplate: Progress updates, status changes, approval workflows
+
+Example:
+    from pyanalysis.mail import Mail
+    from pyanalysis.templates import NotificationTemplate
+
+    template = NotificationTemplate(
+        title="Order Shipped",
+        content="Your order has been shipped.",
+        action_url="https://example.com/track",
+        action_text="Track Order",
+    )
+
+    mail = Mail(username, password)
+    mail.attach(template.to_html())
+    mail.send("Order Update", ["customer@example.com"])
+"""
+
+from pyanalysis.templates.base import BaseTemplate
+from pyanalysis.templates.notification import NotificationTemplate
+from pyanalysis.templates.table import TableTemplate
+from pyanalysis.templates.alert import AlertTemplate
+from pyanalysis.templates.status import StatusTemplate, Step
+
+__all__ = [
+    "BaseTemplate",
+    "NotificationTemplate",
+    "TableTemplate",
+    "AlertTemplate",
+    "StatusTemplate",
+    "Step",
+]

--- a/pyanalysis/templates/_html/alert.html
+++ b/pyanalysis/templates/_html/alert.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+{% set severity_colors = {
+    "critical": {"bg": colors.critical_bg, "border": colors.critical_border, "text": colors.critical},
+    "warning": {"bg": colors.warning_bg, "border": colors.warning_border, "text": colors.warning},
+    "info": {"bg": colors.info_bg, "border": colors.info_border, "text": colors.info}
+} %}
+{% set sev = severity_colors.get(severity, severity_colors.info) %}
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+        <td style="background-color: {{ sev.bg }}; border: 1px solid {{ sev.border }}; border-radius: 4px; padding: 16px;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                    <td width="40" valign="top" style="padding-right: 12px;">
+                        {% if severity == "critical" %}
+                        {{ icons.critical|safe }}
+                        {% elif severity == "warning" %}
+                        {{ icons.warning|safe }}
+                        {% else %}
+                        {{ icons.info|safe }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        <h1 style="{{ styles.title }} margin-bottom: 8px; color: {{ sev.text }};">{{ title }}</h1>
+                        <p style="{{ styles.content }} margin-bottom: 0;">{{ message }}</p>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+    {% if source or timestamp %}
+    <tr>
+        <td style="padding-top: 16px;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                {% if source %}
+                <tr>
+                    <td style="color: {{ colors.text_secondary }}; font-size: 13px; padding-bottom: 4px;">
+                        <strong>来源:</strong> {{ source }}
+                    </td>
+                </tr>
+                {% endif %}
+                {% if timestamp %}
+                <tr>
+                    <td style="color: {{ colors.text_secondary }}; font-size: 13px;">
+                        <strong>时间:</strong> {{ timestamp }}
+                    </td>
+                </tr>
+                {% endif %}
+            </table>
+        </td>
+    </tr>
+    {% endif %}
+    {% if details %}
+    <tr>
+        <td style="padding-top: 16px;">
+            <h3 style="font-size: 14px; font-weight: 600; color: {{ colors.text_primary }}; margin: 0 0 8px 0;">详情</h3>
+            <table role="presentation" style="{{ styles.table }}">
+                {% for key, value in details.items() %}
+                <tr>
+                    <td style="{{ styles.td }} width: 30%; background-color: {{ colors.table_header_bg }}; font-weight: 500;">{{ key }}</td>
+                    <td style="{{ styles.td }}">{{ value }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </td>
+    </tr>
+    {% endif %}
+    {% if action_items %}
+    <tr>
+        <td style="padding-top: 16px;">
+            <h3 style="font-size: 14px; font-weight: 600; color: {{ colors.text_primary }}; margin: 0 0 8px 0;">建议操作</h3>
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                {% for item in action_items %}
+                <tr>
+                    <td style="padding: 4px 0; color: {{ colors.text_primary }}; font-size: 14px;">
+                        {{ loop.index }}. {{ item }}
+                    </td>
+                </tr>
+                {% endfor %}
+            </table>
+        </td>
+    </tr>
+    {% endif %}
+</table>
+{% endblock %}

--- a/pyanalysis/templates/_html/base.html
+++ b/pyanalysis/templates/_html/base.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="{{ locale }}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{% block title %}{% endblock %}</title>
+    <!--[if mso]>
+    <style type="text/css">
+        table {border-collapse: collapse;}
+        .fallback-font {font-family: Arial, sans-serif !important;}
+    </style>
+    <![endif]-->
+</head>
+<body style="margin: 0; padding: 0; background-color: {{ colors.background }}; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color: {{ colors.background }};">
+        <tr>
+            <td align="center" style="padding: 24px 16px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="{{ styles.container }}">
+                    <tr>
+                        <td style="{{ styles.card }}{{ custom_styles }}">
+                            {% block content %}{% endblock %}
+                        </td>
+                    </tr>
+                    {% if footer_text %}
+                    <tr>
+                        <td style="{{ styles.footer }}">
+                            {{ footer_text }}
+                        </td>
+                    </tr>
+                    {% endif %}
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/pyanalysis/templates/_html/notification.html
+++ b/pyanalysis/templates/_html/notification.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    {% if icon %}
+    <tr>
+        <td align="center" style="padding-bottom: 16px;">
+            {{ icons[icon]|safe }}
+        </td>
+    </tr>
+    {% endif %}
+    <tr>
+        <td>
+            <h1 style="{{ styles.title }} text-align: center;">{{ title }}</h1>
+        </td>
+    </tr>
+    {% if subtitle %}
+    <tr>
+        <td>
+            <p style="{{ styles.subtitle }} text-align: center;">{{ subtitle }}</p>
+        </td>
+    </tr>
+    {% endif %}
+    <tr>
+        <td>
+            <p style="{{ styles.content }}">{{ content }}</p>
+        </td>
+    </tr>
+    {% if action_url and action_text %}
+    <tr>
+        <td align="center" style="padding-top: 16px;">
+            <a href="{{ action_url }}" style="{{ styles.button }}">{{ action_text }}</a>
+        </td>
+    </tr>
+    {% endif %}
+</table>
+{% endblock %}

--- a/pyanalysis/templates/_html/status.html
+++ b/pyanalysis/templates/_html/status.html
@@ -1,0 +1,102 @@
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+        <td>
+            <h1 style="{{ styles.title }}">{{ title }}</h1>
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 16px 0;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                    {% if previous_status %}
+                    <td style="text-align: center; padding: 8px;">
+                        <span style="{{ styles.badge }} background-color: {{ colors.border }}; color: {{ colors.text_secondary }};">{{ previous_status }}</span>
+                    </td>
+                    <td style="text-align: center; width: 40px; color: {{ colors.text_muted }};">→</td>
+                    {% endif %}
+                    <td style="text-align: center; padding: 8px;">
+                        <span style="{{ styles.badge }} background-color: {{ colors.success_bg }}; color: {{ colors.success }}; border: 1px solid {{ colors.success_border }};">{{ current_status }}</span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+    {% if progress is not none %}
+    <tr>
+        <td style="padding: 8px 0;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                    <td style="font-size: 13px; color: {{ colors.text_secondary }};">进度</td>
+                    <td style="text-align: right; font-size: 13px; color: {{ colors.primary }}; font-weight: 600;">{{ progress }}%</td>
+                </tr>
+                <tr>
+                    <td colspan="2" style="padding-top: 4px;">
+                        <div style="{{ styles.progress_bar_container }}">
+                            <div style="{{ styles.progress_bar_fill }} width: {{ progress }}%;"></div>
+                        </div>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+    {% endif %}
+    {% if eta %}
+    <tr>
+        <td style="padding: 8px 0; font-size: 13px; color: {{ colors.text_secondary }};">
+            <strong>预计完成时间:</strong> {{ eta }}
+        </td>
+    </tr>
+    {% endif %}
+    {% if steps %}
+    <tr>
+        <td style="padding-top: 16px;">
+            <h3 style="font-size: 14px; font-weight: 600; color: {{ colors.text_primary }}; margin: 0 0 12px 0;">步骤进度</h3>
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                {% for step in steps %}
+                <tr>
+                    <td style="padding: 8px 0; border-bottom: 1px solid {{ colors.border }};">
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                            <tr>
+                                <td width="24" valign="top">
+                                    {% if step.status == "completed" %}
+                                    <span style="display: inline-block; width: 20px; height: 20px; border-radius: 50%; background-color: {{ colors.success }}; color: white; text-align: center; line-height: 20px; font-size: 12px;">✓</span>
+                                    {% elif step.status == "in_progress" %}
+                                    <span style="display: inline-block; width: 20px; height: 20px; border-radius: 50%; background-color: {{ colors.primary }}; color: white; text-align: center; line-height: 20px; font-size: 12px;">●</span>
+                                    {% else %}
+                                    <span style="display: inline-block; width: 20px; height: 20px; border-radius: 50%; background-color: {{ colors.border }}; color: {{ colors.text_muted }}; text-align: center; line-height: 20px; font-size: 12px;">{{ loop.index }}</span>
+                                    {% endif %}
+                                </td>
+                                <td style="padding-left: 8px;">
+                                    <span style="font-size: 14px; color: {% if step.status == 'completed' %}{{ colors.text_secondary }}{% elif step.status == 'in_progress' %}{{ colors.primary }}{% else %}{{ colors.text_muted }}{% endif %};">{{ step.name }}</span>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                {% endfor %}
+            </table>
+        </td>
+    </tr>
+    {% endif %}
+    {% if metadata %}
+    <tr>
+        <td style="padding-top: 16px;">
+            <h3 style="font-size: 14px; font-weight: 600; color: {{ colors.text_primary }}; margin: 0 0 8px 0;">详细信息</h3>
+            <table role="presentation" style="{{ styles.table }}">
+                {% for key, value in metadata.items() %}
+                <tr>
+                    <td style="{{ styles.td }} width: 30%; background-color: {{ colors.table_header_bg }}; font-weight: 500;">{{ key }}</td>
+                    <td style="{{ styles.td }}">{{ value }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </td>
+    </tr>
+    {% endif %}
+</table>
+{% endblock %}

--- a/pyanalysis/templates/_html/table.html
+++ b/pyanalysis/templates/_html/table.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+        <td>
+            <h1 style="{{ styles.title }}">{{ title }}</h1>
+        </td>
+    </tr>
+    {% if summary %}
+    <tr>
+        <td>
+            <p style="{{ styles.subtitle }}">{{ summary }}</p>
+        </td>
+    </tr>
+    {% endif %}
+    <tr>
+        <td>
+            <table role="presentation" style="{{ styles.table }}">
+                <thead>
+                    <tr>
+                        {% if show_row_numbers %}
+                        <th style="{{ styles.th }} width: 40px;">#</th>
+                        {% endif %}
+                        {% for header in headers %}
+                        <th style="{{ styles.th }}">{{ header }}</th>
+                        {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in rows %}
+                    {% set row_index = loop.index0 %}
+                    {% set is_highlighted = row_index in highlight_rows %}
+                    <tr>
+                        {% if show_row_numbers %}
+                        <td style="{{ styles.td }}{% if is_highlighted %} background-color: {{ colors.table_highlight }};{% endif %}">{{ loop.index }}</td>
+                        {% endif %}
+                        {% for cell in row %}
+                        <td style="{{ styles.td }}{% if is_highlighted %} background-color: {{ colors.table_highlight }};{% endif %}">{{ cell }}</td>
+                        {% endfor %}
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+{% endblock %}

--- a/pyanalysis/templates/_styles.py
+++ b/pyanalysis/templates/_styles.py
@@ -1,0 +1,193 @@
+# Shared style constants for email templates
+# All CSS is inline for maximum email client compatibility
+
+# Font stack for Chinese and English
+FONT_FAMILY = (
+    "'PingFang SC', 'Microsoft YaHei', 'Helvetica Neue', "
+    "Helvetica, Arial, sans-serif"
+)
+
+# Color palette
+COLORS = {
+    # Primary colors
+    "primary": "#1890ff",
+    "primary_dark": "#096dd9",
+
+    # Severity colors
+    "critical": "#ff4d4f",
+    "critical_bg": "#fff2f0",
+    "critical_border": "#ffccc7",
+    "warning": "#faad14",
+    "warning_bg": "#fffbe6",
+    "warning_border": "#ffe58f",
+    "info": "#1890ff",
+    "info_bg": "#e6f7ff",
+    "info_border": "#91d5ff",
+    "success": "#52c41a",
+    "success_bg": "#f6ffed",
+    "success_border": "#b7eb8f",
+
+    # Neutral colors
+    "text_primary": "#333333",
+    "text_secondary": "#666666",
+    "text_muted": "#999999",
+    "border": "#e8e8e8",
+    "background": "#f5f5f5",
+    "white": "#ffffff",
+
+    # Table colors
+    "table_header_bg": "#fafafa",
+    "table_row_hover": "#f5f5f5",
+    "table_highlight": "#fffbe6",
+}
+
+# Icon SVGs (inline for email compatibility)
+# noqa: E501 - SVGs are intentionally long single-line strings for email compatibility
+ICONS = {
+    "info": (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" '
+        'viewBox="0 0 24 24" fill="none" stroke="#1890ff" stroke-width="2" '
+        'stroke-linecap="round" stroke-linejoin="round">'
+        '<circle cx="12" cy="12" r="10"></circle>'
+        '<line x1="12" y1="16" x2="12" y2="12"></line>'
+        '<line x1="12" y1="8" x2="12.01" y2="8"></line></svg>'
+    ),
+    "success": (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" '
+        'viewBox="0 0 24 24" fill="none" stroke="#52c41a" stroke-width="2" '
+        'stroke-linecap="round" stroke-linejoin="round">'
+        '<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>'
+        '<polyline points="22 4 12 14.01 9 11.01"></polyline></svg>'
+    ),
+    "warning": (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" '
+        'viewBox="0 0 24 24" fill="none" stroke="#faad14" stroke-width="2" '
+        'stroke-linecap="round" stroke-linejoin="round">'
+        '<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 '
+        '1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>'
+        '<line x1="12" y1="9" x2="12" y2="13"></line>'
+        '<line x1="12" y1="17" x2="12.01" y2="17"></line></svg>'
+    ),
+    "bell": (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" '
+        'viewBox="0 0 24 24" fill="none" stroke="#1890ff" stroke-width="2" '
+        'stroke-linecap="round" stroke-linejoin="round">'
+        '<path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>'
+        '<path d="M13.73 21a2 2 0 0 1-3.46 0"></path></svg>'
+    ),
+    "critical": (
+        '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" '
+        'viewBox="0 0 24 24" fill="none" stroke="#ff4d4f" stroke-width="2" '
+        'stroke-linecap="round" stroke-linejoin="round">'
+        '<circle cx="12" cy="12" r="10"></circle>'
+        '<line x1="15" y1="9" x2="9" y2="15"></line>'
+        '<line x1="9" y1="9" x2="15" y2="15"></line></svg>'
+    ),
+}
+
+# Common inline styles
+STYLES = {
+    "container": f'''
+        width: 100%;
+        max-width: 600px;
+        margin: 0 auto;
+        font-family: {FONT_FAMILY};
+        font-size: 14px;
+        line-height: 1.6;
+        color: {COLORS["text_primary"]};
+    '''.strip(),
+
+    "card": f'''
+        background-color: {COLORS["white"]};
+        border: 1px solid {COLORS["border"]};
+        border-radius: 4px;
+        padding: 24px;
+        margin: 16px 0;
+    '''.strip(),
+
+    "title": f'''
+        font-size: 20px;
+        font-weight: 600;
+        color: {COLORS["text_primary"]};
+        margin: 0 0 16px 0;
+        padding: 0;
+    '''.strip(),
+
+    "subtitle": f'''
+        font-size: 14px;
+        color: {COLORS["text_secondary"]};
+        margin: 0 0 16px 0;
+        padding: 0;
+    '''.strip(),
+
+    "content": f'''
+        font-size: 14px;
+        line-height: 1.8;
+        color: {COLORS["text_primary"]};
+        margin: 0 0 16px 0;
+    '''.strip(),
+
+    "button": f'''
+        display: inline-block;
+        padding: 10px 24px;
+        background-color: {COLORS["primary"]};
+        color: {COLORS["white"]};
+        text-decoration: none;
+        border-radius: 4px;
+        font-size: 14px;
+        font-weight: 500;
+    '''.strip(),
+
+    "footer": f'''
+        font-size: 12px;
+        color: {COLORS["text_muted"]};
+        text-align: center;
+        margin-top: 24px;
+        padding-top: 16px;
+        border-top: 1px solid {COLORS["border"]};
+    '''.strip(),
+
+    "table": '''
+        width: 100%;
+        border-collapse: collapse;
+        margin: 16px 0;
+    '''.strip(),
+
+    "th": f'''
+        background-color: {COLORS["table_header_bg"]};
+        border: 1px solid {COLORS["border"]};
+        padding: 12px;
+        text-align: left;
+        font-weight: 600;
+        font-size: 14px;
+    '''.strip(),
+
+    "td": f'''
+        border: 1px solid {COLORS["border"]};
+        padding: 12px;
+        font-size: 14px;
+    '''.strip(),
+
+    "badge": '''
+        display: inline-block;
+        padding: 4px 8px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 500;
+    '''.strip(),
+
+    "progress_bar_container": f'''
+        width: 100%;
+        height: 8px;
+        background-color: {COLORS["border"]};
+        border-radius: 4px;
+        overflow: hidden;
+        margin: 8px 0;
+    '''.strip(),
+
+    "progress_bar_fill": f'''
+        height: 100%;
+        background-color: {COLORS["primary"]};
+        border-radius: 4px;
+    '''.strip(),
+}

--- a/pyanalysis/templates/alert.py
+++ b/pyanalysis/templates/alert.py
@@ -1,0 +1,82 @@
+from typing import Optional, Dict, List
+
+from pyanalysis.templates.base import BaseTemplate
+
+__all__ = ["AlertTemplate"]
+
+
+class AlertTemplate(BaseTemplate):
+    """Alert email template for exceptions and monitoring.
+
+    Suitable for: exception alerts, monitoring notifications,
+    service outages, etc.
+
+    Args:
+        title: Alert title/heading.
+        message: Alert message describing the issue.
+        severity: Alert severity level ("critical", "warning", "info").
+        source: Optional source/origin of the alert.
+        timestamp: Optional timestamp string.
+        details: Optional dictionary of additional details.
+        action_items: Optional list of recommended actions.
+        footer_text: Optional footer text.
+        custom_styles: Optional additional inline CSS.
+        locale: Language locale (default: "zh-CN").
+
+    Example:
+        template = AlertTemplate(
+            title="Service Exception Alert",
+            message="Database connection timeout",
+            severity="critical",
+            source="order-service",
+            timestamp="2026-01-26 10:30:00",
+            details={
+                "Server": "db-master-01",
+                "Error Code": "ETIMEDOUT",
+            },
+            action_items=[
+                "Check database server status",
+                "Verify network connectivity",
+            ],
+        )
+        html = template.render()
+    """
+
+    _template_name = "alert.html"
+
+    SEVERITY_CRITICAL = "critical"
+    SEVERITY_WARNING = "warning"
+    SEVERITY_INFO = "info"
+
+    def __init__(
+        self,
+        title: str,
+        message: str,
+        severity: str = "info",
+        source: Optional[str] = None,
+        timestamp: Optional[str] = None,
+        details: Optional[Dict[str, str]] = None,
+        action_items: Optional[List[str]] = None,
+        footer_text: Optional[str] = None,
+        custom_styles: Optional[str] = None,
+        locale: str = "zh-CN",
+    ):
+        super().__init__(footer_text, custom_styles, locale)
+        self._title = title
+        self._message = message
+        self._severity = severity
+        self._source = source
+        self._timestamp = timestamp
+        self._details = details
+        self._action_items = action_items
+
+    def _get_template_context(self) -> dict:
+        return {
+            "title": self._title,
+            "message": self._message,
+            "severity": self._severity,
+            "source": self._source,
+            "timestamp": self._timestamp,
+            "details": self._details,
+            "action_items": self._action_items,
+        }

--- a/pyanalysis/templates/base.py
+++ b/pyanalysis/templates/base.py
@@ -1,0 +1,100 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from jinja2 import Environment, FileSystemLoader
+
+from pyanalysis.mail import HtmlContent
+from pyanalysis.templates._styles import COLORS, STYLES, ICONS, FONT_FAMILY
+
+__all__ = ["BaseTemplate"]
+
+# Singleton Jinja2 environment (lazy loaded)
+_jinja_env: Optional[Environment] = None
+
+
+def _get_jinja_env() -> Environment:
+    """Get or create the singleton Jinja2 environment."""
+    global _jinja_env
+    if _jinja_env is None:
+        template_dir = Path(__file__).parent / "_html"
+        _jinja_env = Environment(
+            loader=FileSystemLoader(str(template_dir)),
+            autoescape=True,
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+    return _jinja_env
+
+
+class BaseTemplate(ABC):
+    """Abstract base class for email templates.
+
+    Provides common functionality for rendering Jinja2 templates
+    with shared styles and configuration.
+
+    Args:
+        footer_text: Optional footer text to display at bottom of email.
+        custom_styles: Optional additional inline CSS styles.
+        locale: Language locale code (default: "zh-CN").
+    """
+
+    # Subclasses must set this to their template filename
+    _template_name: str = ""
+
+    def __init__(
+        self,
+        footer_text: Optional[str] = None,
+        custom_styles: Optional[str] = None,
+        locale: str = "zh-CN",
+    ):
+        self._footer_text = footer_text
+        self._custom_styles = custom_styles or ""
+        self._locale = locale
+
+    def _get_base_context(self) -> dict:
+        """Get the base context shared by all templates."""
+        return {
+            "colors": COLORS,
+            "styles": STYLES,
+            "icons": ICONS,
+            "font_family": FONT_FAMILY,
+            "footer_text": self._footer_text,
+            "custom_styles": self._custom_styles,
+            "locale": self._locale,
+        }
+
+    @abstractmethod
+    def _get_template_context(self) -> dict:
+        """Get template-specific context variables.
+
+        Subclasses must implement this to provide their own context.
+        """
+        pass
+
+    def render(self) -> str:
+        """Render the template to an HTML string.
+
+        Returns:
+            The rendered HTML string.
+        """
+        env = _get_jinja_env()
+        template = env.get_template(self._template_name)
+
+        context = self._get_base_context()
+        context.update(self._get_template_context())
+
+        return template.render(**context)
+
+    def to_html(self) -> HtmlContent:
+        """Render the template and wrap in HtmlContent.
+
+        Returns:
+            HtmlContent object that can be directly attached to Mail.
+
+        Example:
+            mail = Mail(username, password)
+            mail.attach(template.to_html())
+            mail.send("Subject", ["receiver@example.com"])
+        """
+        return HtmlContent(self.render())

--- a/pyanalysis/templates/notification.py
+++ b/pyanalysis/templates/notification.py
@@ -1,0 +1,66 @@
+from typing import Optional
+
+from pyanalysis.templates.base import BaseTemplate
+
+__all__ = ["NotificationTemplate"]
+
+
+class NotificationTemplate(BaseTemplate):
+    """Notification email template.
+
+    Suitable for: system notifications, operation reminders,
+    account activation, password reset, etc.
+
+    Args:
+        title: Email title/heading.
+        content: Main content text.
+        action_url: Optional URL for the action button.
+        action_text: Optional text for the action button.
+        subtitle: Optional subtitle text.
+        icon: Optional icon type ("info", "success", "warning", "bell").
+        footer_text: Optional footer text.
+        custom_styles: Optional additional inline CSS.
+        locale: Language locale (default: "zh-CN").
+
+    Example:
+        template = NotificationTemplate(
+            title="Order Shipped",
+            content="Your order has been shipped.",
+            action_url="https://example.com/track",
+            action_text="Track Order",
+            icon="success"
+        )
+        html = template.render()
+    """
+
+    _template_name = "notification.html"
+
+    def __init__(
+        self,
+        title: str,
+        content: str,
+        action_url: Optional[str] = None,
+        action_text: Optional[str] = None,
+        subtitle: Optional[str] = None,
+        icon: Optional[str] = None,
+        footer_text: Optional[str] = None,
+        custom_styles: Optional[str] = None,
+        locale: str = "zh-CN",
+    ):
+        super().__init__(footer_text, custom_styles, locale)
+        self._title = title
+        self._content = content
+        self._action_url = action_url
+        self._action_text = action_text
+        self._subtitle = subtitle
+        self._icon = icon
+
+    def _get_template_context(self) -> dict:
+        return {
+            "title": self._title,
+            "content": self._content,
+            "action_url": self._action_url,
+            "action_text": self._action_text,
+            "subtitle": self._subtitle,
+            "icon": self._icon,
+        }

--- a/pyanalysis/templates/status.py
+++ b/pyanalysis/templates/status.py
@@ -1,0 +1,91 @@
+from typing import Optional, Dict, List, TypedDict
+
+from pyanalysis.templates.base import BaseTemplate
+
+__all__ = ["StatusTemplate", "Step"]
+
+
+class Step(TypedDict, total=False):
+    """Step definition for StatusTemplate.
+
+    Attributes:
+        name: Step name/description.
+        status: Step status ("pending", "in_progress", "completed").
+    """
+    name: str
+    status: str  # "pending", "in_progress", "completed"
+
+
+class StatusTemplate(BaseTemplate):
+    """Status email template for progress updates.
+
+    Suitable for: progress updates, status changes,
+    approval workflows, etc.
+
+    Args:
+        title: Email title/heading.
+        current_status: Current status text.
+        previous_status: Optional previous status (shows status change).
+        progress: Optional progress percentage (0-100).
+        steps: Optional list of steps with status.
+        eta: Optional estimated completion time.
+        metadata: Optional dictionary of additional metadata.
+        footer_text: Optional footer text.
+        custom_styles: Optional additional inline CSS.
+        locale: Language locale (default: "zh-CN").
+
+    Example:
+        template = StatusTemplate(
+            title="Order Status Update",
+            current_status="Shipped",
+            previous_status="Processing",
+            progress=75,
+            steps=[
+                {"name": "Order Placed", "status": "completed"},
+                {"name": "Payment Confirmed", "status": "completed"},
+                {"name": "Shipped", "status": "in_progress"},
+                {"name": "Delivered", "status": "pending"},
+            ],
+            eta="2026-01-28",
+            metadata={
+                "Order ID": "ORD-12345",
+                "Carrier": "Express Delivery",
+            },
+        )
+        html = template.render()
+    """
+
+    _template_name = "status.html"
+
+    def __init__(
+        self,
+        title: str,
+        current_status: str,
+        previous_status: Optional[str] = None,
+        progress: Optional[int] = None,
+        steps: Optional[List[Step]] = None,
+        eta: Optional[str] = None,
+        metadata: Optional[Dict[str, str]] = None,
+        footer_text: Optional[str] = None,
+        custom_styles: Optional[str] = None,
+        locale: str = "zh-CN",
+    ):
+        super().__init__(footer_text, custom_styles, locale)
+        self._title = title
+        self._current_status = current_status
+        self._previous_status = previous_status
+        self._progress = progress
+        self._steps = steps
+        self._eta = eta
+        self._metadata = metadata
+
+    def _get_template_context(self) -> dict:
+        return {
+            "title": self._title,
+            "current_status": self._current_status,
+            "previous_status": self._previous_status,
+            "progress": self._progress,
+            "steps": self._steps,
+            "eta": self._eta,
+            "metadata": self._metadata,
+        }

--- a/pyanalysis/templates/table.py
+++ b/pyanalysis/templates/table.py
@@ -1,0 +1,139 @@
+from typing import Optional, List, Set, Dict, Any
+
+from pyanalysis.templates.base import BaseTemplate
+
+__all__ = ["TableTemplate"]
+
+
+class TableTemplate(BaseTemplate):
+    """Table email template for data reports and lists.
+
+    Suitable for: data reports, list displays, daily reports, etc.
+
+    Args:
+        title: Email title/heading.
+        headers: List of column header names.
+        rows: List of row data (each row is a list of cell values).
+        summary: Optional summary text shown below the title.
+        highlight_rows: Optional set of row indices to highlight (0-indexed).
+        show_row_numbers: Whether to show row numbers (default: False).
+        footer_text: Optional footer text.
+        custom_styles: Optional additional inline CSS.
+        locale: Language locale (default: "zh-CN").
+
+    Example:
+        template = TableTemplate(
+            title="Daily Sales Report",
+            headers=["Product", "Quantity", "Amount"],
+            rows=[
+                ["Product A", "10", "$1000"],
+                ["Product B", "5", "$500"],
+            ],
+            summary="Total: $1500",
+            highlight_rows={1},
+        )
+        html = template.render()
+    """
+
+    _template_name = "table.html"
+
+    def __init__(
+        self,
+        title: str,
+        headers: List[str],
+        rows: List[List[str]],
+        summary: Optional[str] = None,
+        highlight_rows: Optional[Set[int]] = None,
+        show_row_numbers: bool = False,
+        footer_text: Optional[str] = None,
+        custom_styles: Optional[str] = None,
+        locale: str = "zh-CN",
+    ):
+        super().__init__(footer_text, custom_styles, locale)
+        self._title = title
+        self._headers = headers
+        self._rows = rows
+        self._summary = summary
+        self._highlight_rows = highlight_rows or set()
+        self._show_row_numbers = show_row_numbers
+
+    def _get_template_context(self) -> dict:
+        return {
+            "title": self._title,
+            "headers": self._headers,
+            "rows": self._rows,
+            "summary": self._summary,
+            "highlight_rows": self._highlight_rows,
+            "show_row_numbers": self._show_row_numbers,
+        }
+
+    @classmethod
+    def from_dicts(
+        cls,
+        title: str,
+        data: List[Dict[str, Any]],
+        columns: Optional[List[str]] = None,
+        summary: Optional[str] = None,
+        highlight_rows: Optional[Set[int]] = None,
+        show_row_numbers: bool = False,
+        footer_text: Optional[str] = None,
+        custom_styles: Optional[str] = None,
+        locale: str = "zh-CN",
+    ) -> "TableTemplate":
+        """Create a TableTemplate from a list of dictionaries.
+
+        Args:
+            title: Email title/heading.
+            data: List of dictionaries containing row data.
+            columns: Optional list of column keys to include (in order).
+                     If not specified, uses keys from the first dict.
+            summary: Optional summary text.
+            highlight_rows: Optional set of row indices to highlight.
+            show_row_numbers: Whether to show row numbers.
+            footer_text: Optional footer text.
+            custom_styles: Optional additional inline CSS.
+            locale: Language locale.
+
+        Returns:
+            A configured TableTemplate instance.
+
+        Example:
+            template = TableTemplate.from_dicts(
+                title="User List",
+                data=[
+                    {"name": "Alice", "age": 25, "city": "NYC"},
+                    {"name": "Bob", "age": 30, "city": "LA"},
+                ],
+                columns=["name", "city"],  # Only show these columns
+            )
+        """
+        if not data:
+            return cls(
+                title=title,
+                headers=[],
+                rows=[],
+                summary=summary,
+                highlight_rows=highlight_rows,
+                show_row_numbers=show_row_numbers,
+                footer_text=footer_text,
+                custom_styles=custom_styles,
+                locale=locale,
+            )
+
+        if columns is None:
+            columns = list(data[0].keys())
+
+        headers = columns
+        rows = [[str(row.get(col, "")) for col in columns] for row in data]
+
+        return cls(
+            title=title,
+            headers=headers,
+            rows=rows,
+            summary=summary,
+            highlight_rows=highlight_rows,
+            show_row_numbers=show_row_numbers,
+            footer_text=footer_text,
+            custom_styles=custom_styles,
+            locale=locale,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
     "arrow>=1.0.0",
     "PyMySQL>=1.0.0",
+    "Jinja2>=3.0.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 arrow>=1.0.0
 PyMySQL>=1.0.0
+Jinja2>=3.0.0

--- a/test/templates.py
+++ b/test/templates.py
@@ -1,0 +1,401 @@
+import unittest
+
+from pyanalysis.mail import HtmlContent
+from pyanalysis.templates import (
+    BaseTemplate,
+    NotificationTemplate,
+    TableTemplate,
+    AlertTemplate,
+    StatusTemplate,
+)
+
+
+class TestNotificationTemplate(unittest.TestCase):
+    """Test cases for NotificationTemplate."""
+
+    def test_basic_render(self):
+        """Test basic notification rendering."""
+        template = NotificationTemplate(
+            title="Test Title",
+            content="Test content message.",
+        )
+        html = template.render()
+
+        self.assertIn("Test Title", html)
+        self.assertIn("Test content message.", html)
+        self.assertIn("<!DOCTYPE html>", html)
+
+    def test_with_action_button(self):
+        """Test notification with action button."""
+        template = NotificationTemplate(
+            title="Action Required",
+            content="Please click the button.",
+            action_url="https://example.com/action",
+            action_text="Click Here",
+        )
+        html = template.render()
+
+        self.assertIn("https://example.com/action", html)
+        self.assertIn("Click Here", html)
+
+    def test_with_icon(self):
+        """Test notification with different icons."""
+        for icon in ["info", "success", "warning", "bell"]:
+            template = NotificationTemplate(
+                title="Icon Test",
+                content="Testing icon.",
+                icon=icon,
+            )
+            html = template.render()
+            self.assertIn("<svg", html)
+
+    def test_with_subtitle(self):
+        """Test notification with subtitle."""
+        template = NotificationTemplate(
+            title="Main Title",
+            content="Content here.",
+            subtitle="Subtitle text",
+        )
+        html = template.render()
+
+        self.assertIn("Subtitle text", html)
+
+    def test_to_html_returns_html_content(self):
+        """Test that to_html returns HtmlContent instance."""
+        template = NotificationTemplate(
+            title="Test",
+            content="Test content.",
+        )
+        result = template.to_html()
+
+        self.assertIsInstance(result, HtmlContent)
+
+    def test_with_footer(self):
+        """Test notification with footer text."""
+        template = NotificationTemplate(
+            title="Test",
+            content="Content",
+            footer_text="Footer message here",
+        )
+        html = template.render()
+
+        self.assertIn("Footer message here", html)
+
+    def test_locale_setting(self):
+        """Test locale is set in HTML."""
+        template = NotificationTemplate(
+            title="Test",
+            content="Content",
+            locale="en-US",
+        )
+        html = template.render()
+
+        self.assertIn('lang="en-US"', html)
+
+
+class TestTableTemplate(unittest.TestCase):
+    """Test cases for TableTemplate."""
+
+    def test_basic_render(self):
+        """Test basic table rendering."""
+        template = TableTemplate(
+            title="Sales Report",
+            headers=["Product", "Quantity", "Amount"],
+            rows=[
+                ["Product A", "10", "$100"],
+                ["Product B", "5", "$50"],
+            ],
+        )
+        html = template.render()
+
+        self.assertIn("Sales Report", html)
+        self.assertIn("Product", html)
+        self.assertIn("Quantity", html)
+        self.assertIn("Amount", html)
+        self.assertIn("Product A", html)
+        self.assertIn("$100", html)
+
+    def test_with_summary(self):
+        """Test table with summary text."""
+        template = TableTemplate(
+            title="Report",
+            headers=["Col1", "Col2"],
+            rows=[["a", "b"]],
+            summary="Total: $150",
+        )
+        html = template.render()
+
+        self.assertIn("Total: $150", html)
+
+    def test_with_row_numbers(self):
+        """Test table with row numbers enabled."""
+        template = TableTemplate(
+            title="Report",
+            headers=["Name"],
+            rows=[["Alice"], ["Bob"]],
+            show_row_numbers=True,
+        )
+        html = template.render()
+
+        self.assertIn("#", html)
+
+    def test_from_dicts(self):
+        """Test creating table from list of dictionaries."""
+        data = [
+            {"name": "Alice", "age": "25", "city": "NYC"},
+            {"name": "Bob", "age": "30", "city": "LA"},
+        ]
+        template = TableTemplate.from_dicts(
+            title="User List",
+            data=data,
+        )
+        html = template.render()
+
+        self.assertIn("User List", html)
+        self.assertIn("name", html)
+        self.assertIn("Alice", html)
+        self.assertIn("Bob", html)
+
+    def test_from_dicts_with_columns(self):
+        """Test from_dicts with specific columns."""
+        data = [
+            {"name": "Alice", "age": "25", "city": "NYC"},
+            {"name": "Bob", "age": "30", "city": "LA"},
+        ]
+        template = TableTemplate.from_dicts(
+            title="Filtered",
+            data=data,
+            columns=["name", "city"],
+        )
+        html = template.render()
+
+        self.assertIn("name", html)
+        self.assertIn("city", html)
+        # age should not be rendered as header
+        self.assertNotIn(">age<", html)
+
+    def test_from_dicts_empty_data(self):
+        """Test from_dicts with empty data list."""
+        template = TableTemplate.from_dicts(
+            title="Empty",
+            data=[],
+        )
+        html = template.render()
+
+        self.assertIn("Empty", html)
+
+    def test_highlight_rows(self):
+        """Test row highlighting."""
+        template = TableTemplate(
+            title="Report",
+            headers=["Name"],
+            rows=[["Alice"], ["Bob"], ["Charlie"]],
+            highlight_rows={1},
+        )
+        html = template.render()
+        # Highlight color should be present
+        self.assertIn("#fffbe6", html)
+
+
+class TestAlertTemplate(unittest.TestCase):
+    """Test cases for AlertTemplate."""
+
+    def test_basic_render(self):
+        """Test basic alert rendering."""
+        template = AlertTemplate(
+            title="Alert Title",
+            message="Something went wrong.",
+        )
+        html = template.render()
+
+        self.assertIn("Alert Title", html)
+        self.assertIn("Something went wrong.", html)
+
+    def test_severity_levels(self):
+        """Test different severity levels."""
+        for severity in ["critical", "warning", "info"]:
+            template = AlertTemplate(
+                title="Test Alert",
+                message="Test message",
+                severity=severity,
+            )
+            html = template.render()
+            self.assertIn("<svg", html)
+
+    def test_with_source_and_timestamp(self):
+        """Test alert with source and timestamp."""
+        template = AlertTemplate(
+            title="Error",
+            message="Connection failed",
+            source="api-server",
+            timestamp="2026-01-26 10:30:00",
+        )
+        html = template.render()
+
+        self.assertIn("api-server", html)
+        self.assertIn("2026-01-26 10:30:00", html)
+
+    def test_with_details(self):
+        """Test alert with details dictionary."""
+        template = AlertTemplate(
+            title="Error",
+            message="Database error",
+            details={
+                "Server": "db-master",
+                "Error Code": "ETIMEDOUT",
+            },
+        )
+        html = template.render()
+
+        self.assertIn("Server", html)
+        self.assertIn("db-master", html)
+        self.assertIn("Error Code", html)
+        self.assertIn("ETIMEDOUT", html)
+
+    def test_with_action_items(self):
+        """Test alert with action items."""
+        template = AlertTemplate(
+            title="Alert",
+            message="Issue detected",
+            action_items=[
+                "Check server status",
+                "Review logs",
+                "Contact support",
+            ],
+        )
+        html = template.render()
+
+        self.assertIn("Check server status", html)
+        self.assertIn("Review logs", html)
+        self.assertIn("Contact support", html)
+
+    def test_critical_severity_colors(self):
+        """Test critical severity uses correct colors."""
+        template = AlertTemplate(
+            title="Critical",
+            message="System down",
+            severity="critical",
+        )
+        html = template.render()
+
+        # Critical background color
+        self.assertIn("#fff2f0", html)
+
+
+class TestStatusTemplate(unittest.TestCase):
+    """Test cases for StatusTemplate."""
+
+    def test_basic_render(self):
+        """Test basic status rendering."""
+        template = StatusTemplate(
+            title="Status Update",
+            current_status="Active",
+        )
+        html = template.render()
+
+        self.assertIn("Status Update", html)
+        self.assertIn("Active", html)
+
+    def test_with_status_change(self):
+        """Test status with previous status."""
+        template = StatusTemplate(
+            title="Status Change",
+            current_status="Approved",
+            previous_status="Pending",
+        )
+        html = template.render()
+
+        self.assertIn("Approved", html)
+        self.assertIn("Pending", html)
+        self.assertIn("→", html)
+
+    def test_with_progress(self):
+        """Test status with progress bar."""
+        template = StatusTemplate(
+            title="Progress",
+            current_status="In Progress",
+            progress=75,
+        )
+        html = template.render()
+
+        self.assertIn("75%", html)
+
+    def test_with_steps(self):
+        """Test status with steps."""
+        template = StatusTemplate(
+            title="Workflow",
+            current_status="Step 2",
+            steps=[
+                {"name": "Step 1", "status": "completed"},
+                {"name": "Step 2", "status": "in_progress"},
+                {"name": "Step 3", "status": "pending"},
+            ],
+        )
+        html = template.render()
+
+        self.assertIn("Step 1", html)
+        self.assertIn("Step 2", html)
+        self.assertIn("Step 3", html)
+
+    def test_with_eta(self):
+        """Test status with ETA."""
+        template = StatusTemplate(
+            title="Task",
+            current_status="Running",
+            eta="2026-01-30 15:00",
+        )
+        html = template.render()
+
+        self.assertIn("2026-01-30 15:00", html)
+
+    def test_with_metadata(self):
+        """Test status with metadata."""
+        template = StatusTemplate(
+            title="Order Status",
+            current_status="Shipped",
+            metadata={
+                "Order ID": "ORD-12345",
+                "Carrier": "Express",
+            },
+        )
+        html = template.render()
+
+        self.assertIn("Order ID", html)
+        self.assertIn("ORD-12345", html)
+        self.assertIn("Carrier", html)
+        self.assertIn("Express", html)
+
+    def test_zero_progress(self):
+        """Test progress bar with 0%."""
+        template = StatusTemplate(
+            title="Starting",
+            current_status="Initializing",
+            progress=0,
+        )
+        html = template.render()
+
+        self.assertIn("0%", html)
+
+
+class TestBaseTemplate(unittest.TestCase):
+    """Test cases for BaseTemplate abstract class."""
+
+    def test_cannot_instantiate_directly(self):
+        """Test that BaseTemplate cannot be instantiated directly."""
+        with self.assertRaises(TypeError):
+            BaseTemplate()
+
+    def test_custom_styles(self):
+        """Test custom styles are applied."""
+        template = NotificationTemplate(
+            title="Test",
+            content="Content",
+            custom_styles=" color: red;",
+        )
+        html = template.render()
+
+        self.assertIn("color: red;", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add new `pyanalysis.templates` module with 4 ready-to-use email HTML templates
- **NotificationTemplate**: system notifications, reminders, password resets
- **TableTemplate**: data reports, list displays (with `from_dicts()` helper)
- **AlertTemplate**: exception alerts, monitoring notifications  
- **StatusTemplate**: progress updates, status changes, approval workflows
- All templates use inline CSS for maximum email client compatibility (including Outlook)
- Support Chinese fonts (PingFang SC, Microsoft YaHei)
- Add Jinja2>=3.0.0 dependency

## Test plan

- [x] Run `python3 -m unittest test/templates.py` - 29 tests pass
- [x] Run `flake8 pyanalysis/templates/` - no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)