### PR TITLE
fix: add noqa comment to suppress E402 lint error

### DIFF
--- a/test/mail_preview.py
+++ b/test/mail_preview.py
@@ -13,7 +13,7 @@ import sys
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from pyanalysis.mail_templates import (
+from pyanalysis.mail_templates import (  # noqa: E402
     NotificationTemplate,
     TableTemplate,
     AlertTemplate,


### PR DESCRIPTION
## Summary
- Add `# noqa: E402` comment to suppress flake8 E402 lint error in `test/mail_preview.py`
- The import after `sys.path.insert()` is necessary for loading local modules but triggers this warning

## Test plan
- [x] Run `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` to verify no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)